### PR TITLE
update Netlify function path to /logs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
 
 [[edge_functions]]
 function = "umair-logs"
-path = "/"
+path = "/logs"


### PR DESCRIPTION
This pull request includes a small change to the `netlify.toml` file. The change updates the path for the `umair-logs` function from `/` to `/logs`.